### PR TITLE
Mise en place du zoom et du décalage

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,19 +1,35 @@
 # DONE:
-+ Mise en place de .gitignore
-+ Mise en place partielle du zoom
-  + Dessins et textes ok
-  + l'épaisseur des traits (fonctions et links) est affecté par le zoom
++ Zoom : self.can.scale() abandonné dans GUI.draw() à cause des textes qui ne suivent pas
++ Zoom : Problème de décalage des zones de sélection (move, erase...) réglé
+-> Affectation du coef zoom dans GUI.draw_destination_outine
+-> Ajout du paramètre zoom dans tl.nearest_objet()
+-> Modification du déplacement de la souris
+-> Fix : Hauteur des fonctions
++ Zoom : Contrôlé aussi par la molette de la souris event.delta ou event.num selon OS
+ + CTRL+a : Créé un groupe regroupant tous les éléments
+   -> Lancer la méthode GROUP.update_coordinates() recadrer la dimension
+ + CTRL+o : Reset_origin (reset l'offset et le zoom de l'affichage)
++ Espace trop grand entre label et type des noeuds résolu
++ self.margin renommé en self.blanck pour libérer le nom de la méthode
++ refactoring des attribut GUI.MARIN* self.margins est bien affecté par le zoom
++ Taille des noeuds et des flèches correctement affectées par le zoom
 
-# BUG : 
-+ Mettre en place zoom sur self.can Ok
-  + Décalage sur les zones de sélection (move, erase...)
+# TOFIX : 
++ Espace trop grand et étrangement cumulatif entre le noeud et la position du label
++ Erreur au positionnement des bornes pour le tracé des groupes
++ Remettre le try/except dans GUI.draw()
+
+# TOTEST :
++ Zoom/Molette de souris sous Windows
 
 # TODO:
-+ CTRL+a : Créé un groupe regroupant tous les éléments
++ Code mort au début de nearest ?
 + Mettre à jour l'aide. Expliquer
   + Déplacement : CRTL+v
   + Annulation : CTRL+z
-  + Construction d'un group et utilité (déplacement, duplication, chgt groupé du positionnement, suppession)
+  + Sélection totale : CTRL+a
+  + Zoom + et Zoom - : CTRL+q et CTRL+w
+  + Construction d'un groupe et utilité (déplacement, duplication, chgt groupé du positionnement, suppession)
 + Lever des exceptions plus propres dans les try (au lieu de pass)
 
 Alternative/Existant : https://app.diagrams.net/

--- a/group.py
+++ b/group.py
@@ -97,10 +97,16 @@ class Group:
         self.update_coordinates()
         return True
 
-    def search_elements_in(self, diagram, origin, destination):
+    def search_elements_in(self, diagram, origin, destination, all=False):
         elements = list()
         x_origin, y_origin = origin
-        objects = tl.search_in_rectangle(diagram, origin, destination)
+        if all:
+            objects = list(diagram.functions.values())
+            for node in list(diagram.nodes.values()):
+                if node.free:
+                    objects.append(node)
+        else:
+            objects = tl.search_in_rectangle(diagram, origin, destination)
         nodes = []
         for ref, element in enumerate(objects):
             x_element, y_element = element.position

--- a/main.py
+++ b/main.py
@@ -10,8 +10,20 @@ if __name__ == "__main__":
     window.tk.bind("<Button-1>", window.left_click)
     window.tk.bind("<Button-3>", window.right_click)
     window.tk.bind("<Escape>", window.right_click)
+    # General keyboard controls: Select all, Copy/Paste, Undo
+    window.tk.bind("<Control -a>", window.group_all)
     window.tk.bind("<Control -c>", window.copy)
     window.tk.bind("<Control -z>", window.undo)
+    # Detect mouse wheel with Windows
+    window.tk.bind("<MouseWheel>", window.zoom_wheel)
+    # Detect mouse wheel with Linux
+    window.tk.bind("<Button-4>", window.zoom_wheel)
+    window.tk.bind("<Button-5>", window.zoom_wheel)
+    # Keyboard zoom control
+    window.tk.bind("<Control -o>", window.reset_origin)
     window.tk.bind("<Control -q>", window.zoom_more)
     window.tk.bind("<Control -w>", window.zoom_less)
+    # Dectecting dragging: Move the reference
+    window.tk.bind("<B1-Motion>", window.drag_origin)
+
     window.tk.mainloop()

--- a/tools.py
+++ b/tools.py
@@ -245,10 +245,13 @@ def nearest(mouse_position, targets):
     return nearest_target, nearest_target_distance
 
 
-def nearest_objet(mouse_position, diagram, target_types="movable"):
+def nearest_objet(mouse_position, diagram, zoom=1, target_types="movable"):
     """Return the nearest object from the cursor.
     target_types can be "all" (default), "function" or "node"
     """
+    x_mouse = mouse_position[0]
+    y_mouse = mouse_position[1]
+    mouse_position = (x_mouse, y_mouse)
     population = []
     population += diagram.groups.values()
     for group in diagram.groups.values():
@@ -278,9 +281,28 @@ def get_dimension(origin, destination):
     y = destination[1] - origin[1]
     return (x, y)
 
+def offset(origin, zoom, x, y):
+    """ origin is a list [x_offset, y_offset].
+        Return the list modified by thr zoom factor and the offset (origin).
+    """
+    return [(origin[0])+zoom*x, (origin[1])+zoom*y]
+
+def subset(origin, zoom, x, y):
+    """ origin is a list [x_offset, y_offset].
+        Take the x,y position of the mouse. Translate it by the offset (origin) and divide it by the zoom factor.
+        Return the corresponding position.
+    """
+    return [(x-origin[0])//zoom , (y-origin[1])//zoom]
+
+def update_dict_ratio(dico:dict, zoom:float):
+    """ Retrun the dico with all values multiplied by zoom.
+    """
+    for key, value in dico.items():
+        dico[key] = value * zoom
+    return dico
 
 def search_in_rectangle(diagram, origin, destination):
-    """Return the list of functions end nodes in the rectangle defined by the positions origin (x1, y1) and destination (x2, y2)."""
+    """Return the list of functions and nodes in the rectangle defined by the positions origin (x1, y1) and destination (x2, y2)."""
     objects = []
     x1, y1 = origin
     x2, y2 = destination


### PR DESCRIPTION
+ Zoom : self.can.scale() abandonné dans GUI.draw() à cause des texte…s qui ne suivent pas
+ Zoom : Problème de décalage des zones de sélection (move, erase...) réglé -> Affectation du coef zoom dans GUI.draw_destination_outine -> Ajout du paramètre zoom dans tl.nearest_objet() -> Modification du déplacement de la souris
-> Fix : Hauteur des fonctions
+ Zoom : Contrôlé aussi par la molette de la souris event.delta ou event.num selon OS
 + CTRL+a : Créé un groupe regroupant tous les éléments -> Lancer la méthode GROUP.update_coordinates() recadrer la dimension
 + CTRL+o : Reset_origin (reset l'offset et le zoom de l'affichage)
+ Espace trop grand entre label et type des noeuds résolu
+ self.margin renommé en self.blanck pour libérer le nom de la méthode
+ refactoring des attribut GUI.MARIN* self.margins est bien affecté par le zoom
+ Taille des noeuds et des flèches correctement affectées par le zoom