### PR TITLE
+ CTRL+s : Lance la sauvegarde si l'état est à 1

### DIFF
--- a/GUI.py
+++ b/GUI.py
@@ -693,6 +693,10 @@ class Window:
         self.memory.add(self.diagram.export_to_text())
         return True
 
+    def save(self, event=None):
+        if self.state == 1:
+            self.cmd_save()
+
     @Decorators.disable_if_editing
     def cmd_save(self):
         """Save the configuration of the diagram as a file."""
@@ -803,7 +807,6 @@ class Window:
             )
             new_group.elements = elements
             ok = new_group.update_coordinates()
-            print("Update ?", ok)
             self.diagram.add_group(new_group)
             self.destination = new_group
             self.edit(self.destination)

--- a/TODO.md
+++ b/TODO.md
@@ -1,20 +1,17 @@
 # DONE:
-+ Précision du mode "fixed" dans les commentaires des functions
-+ Correction de la lecture du commentaire "#fixed" pour les noeurds.
-+ Mise à jour des dimensions et de l'affichage lors des changements de préférences (Window_configuration)
++ CTRL+s : Lance la sauvegarde si l'état est à 1
++ Comparaison des tailles de texte entre Windows et Ubuntu (Rapport de 1.4 en moyenne)
++ print supprimer dans tools.character_dimensions et GUI.group_all
++ Inconsolas comme police par défaut dans toutes les préférences
 
-# TOFIX : 
-+ L'affichage est erroné sur Windows (police trop grandes par rapport à la mesure de tools.character_dimensions)
+# TOFIX :
 
 # TOTEST :
 
-
 # TODO:
-+ Virer les prints ds tools.character_dimensions
-+ CTRL+s : Save
-+ Repasser temporairement en zoom = 1, le temps de l'enregistrement. Puis repasser en zoom d'origine.
 + Shortcuts dans l'aide
 + Mettre à jour l'aide. Expliquer
+  + Sauvegarde : CTRL+s
   + Déplacement : CRTL+v
   + Annulation : CTRL+z et CTRL+y
   + Sélection totale : CTRL+a

--- a/main.py
+++ b/main.py
@@ -11,6 +11,7 @@ if __name__ == "__main__":
     window.tk.bind("<Button-3>", window.right_click)
     window.tk.bind("<Escape>", window.right_click)
     # General keyboard controls: Select all, Copy/Paste, Undo
+    window.tk.bind("<Control -s>", window.save)
     window.tk.bind("<Control -a>", window.group_all)
     window.tk.bind("<Control -c>", window.copy)
     window.tk.bind("<Control -z>", window.undo)

--- a/preferences.json
+++ b/preferences.json
@@ -1,6 +1,6 @@
 {
     "main background color_color": "#1e1e1e",
-    "police": "Consolas",
+    "police": "Inconsolas",
     "title background color_color": "#444444",
     "title size_int": "18",
     "text color_color": "#d0d0d0",

--- a/preferences_default_dark.json
+++ b/preferences_default_dark.json
@@ -1,6 +1,6 @@
 {
     "main background color_color": "#1e1e1e",
-    "police": "Consolas",
+    "police": "Inconsolas",
     "title background color_color": "#444444",
     "title size_int": "18",
     "text color_color": "#d0d0d0",

--- a/preferences_default_light.json
+++ b/preferences_default_light.json
@@ -1,6 +1,6 @@
 {
     "main background color_color": "white",
-    "police": "Consolas",
+    "police": "Inconsolas",
     "title background color_color": "#dddddd",
     "title size_int": "18",
     "text color_color": "black",

--- a/preferences_security.json
+++ b/preferences_security.json
@@ -1,6 +1,6 @@
 {
     "main background color_color": "#1e1e1e",
-    "police": "Consolas",
+    "police": "Inconsolas",
     "title background color_color": "#444444",
     "title size_int": "18",
     "text color_color": "#d0d0d0",

--- a/tools.py
+++ b/tools.py
@@ -75,7 +75,6 @@ def character_dimensions(police, size):
 
     nb_pixels_height = tkfont.Font(size=size, family=police).metrics("linespace")
     nb_pixels_width = tkfont.Font(size=size, family=police).measure("X")
-    print("dimensions (", police, ",", size, "): ", nb_pixels_width, nb_pixels_height)
     return (nb_pixels_width, nb_pixels_height)
 
 

--- a/window_configuration.py
+++ b/window_configuration.py
@@ -118,7 +118,6 @@ class Window_configuration:
             self.parent.text_char_width,
             self.parent.text_char_height,
         ) = tl.character_dimensions(police, text_size)
-        self.parent.memory.add(self.parent.diagram.export_to_text())
         self.parent.auto_resize_blocks()
         self.parent.position_functions_nodes()
         self.parent.memory.add(self.parent.diagram.export_to_text())


### PR DESCRIPTION
+ Comparaison des tailles de texte entre Windows et Ubuntu (Rapport de 1.4 en moyenne)
+ print supprimer dans tools.character_dimensions et GUI.group_all
+ Inconsolas comme police par défaut dans toutes les préférences