### PR TITLE
Ajout de commentaires (exemples de valeurs) pour les noeuds

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,21 +1,26 @@
 # DONE:
++ tl.darker()
++ label et comment justification dans GUI.draw_nodes()
++ affichage du commentaire en couleur plus sombre que l'annotation de type
++ rectification de la marge sur les noms de groupes (affectés par le zoom)
++ rectification de l'épaisseur des pointillés des commentaires et des groupes en fonction du zoom
++ Ajout d'une couleur de commentaire paramétrable dans les préférences
 
 # TOFIX :
++ Enregistrment des commentaires des noeuds
++ Lecture des commentaires des noeuds
 
 # TOTEST :
 
 # TODO:
-Symbole '='dans les description de noeuds :
-  + Entrées de fonctions : Affecte la valeur par défaut
-  + Noeuds libres : Affiche un exemple de valeur sous le noeuds (respectant l'alignement supérieur) ?s
-
 Renderer : Programme .py qui génère directement le SVG en fonction du nom de fichier de sauvegarde txt
   + render.py chemin/source.txt chemin/destination.svg
   + render.py chemin/source.txt => chemin/source.svg si la destination n'est pas renseignée
 Commandes:
-<Auto> : Lance le mode auto en fin de lecture de fichier 
+<Auto> : Lance le mode auto en fin de lecture de fichier.
 
 Alternatives/Existants : 
 https://app.diagrams.net/
 https://github.com/kevinpt/symbolator
+
 

--- a/node.py
+++ b/node.py
@@ -15,6 +15,7 @@ class Node:
         self.connections = []  # List of nodes connected
         self.fixed = False  # True if the position is fixed.
         self.justify = None  # "left", "center","separator", "right" or None for default
+        self.comment = ""  # Comment to be displayed in a box below the node.
         self.floor = -1  # Depth in the graph. Leaves at 0.
         for k, v in kwargs.items():
             if k in self.__dict__:
@@ -24,7 +25,7 @@ class Node:
 
     def __repr__(self):
         line = self.name
-        line = self.name + ":" + self.annotation + ' '
+        line = self.name + ":" + self.annotation + " "
         line += str(len(self.connections)) + " Connection(s) "
         if self.position != []:
             line += "Position: " + str(self.position)

--- a/preferences.json
+++ b/preferences.json
@@ -15,6 +15,7 @@
     "group margin_int": "20",
     "line color_color": "#858585",
     "line thickness_int": "1",
+    "comment color_color": "#ffcc32",
     "automatic spacing_int": "0",
     "enable loopback_bool": 0,
     "smooth lines_bool": 1,

--- a/preferences_default_dark.json
+++ b/preferences_default_dark.json
@@ -15,6 +15,7 @@
     "group margin_int": "20",
     "line color_color": "#858585",
     "line thickness_int": "1",
+    "comment color_color": "#ffcc32",
     "automatic spacing_int": "0",
     "enable loopback_bool": 0,
     "smooth lines_bool": 1,

--- a/preferences_default_light.json
+++ b/preferences_default_light.json
@@ -15,6 +15,7 @@
     "group margin_int": "20",
     "line color_color": "black",
     "line thickness_int": "1",
+    "comment color_color": "#df8512",
     "automatic spacing_int": "0",
     "enable loopback_bool": 0,
     "smooth lines_bool": 1,

--- a/preferences_security.json
+++ b/preferences_security.json
@@ -15,6 +15,7 @@
     "group margin_int": "20",
     "line color_color": "#858585",
     "line thickness_int": "1",
+    "comment color_color": "#ffcc32",
     "automatic spacing_int": "0",
     "enable loopback_bool": 0,
     "smooth lines_bool": 1,

--- a/tools.py
+++ b/tools.py
@@ -481,6 +481,35 @@ def cast_to_color(color_str: str, col_format=None) -> str:
     return None
 
 
+def byte_homotety(value: int, zoom: float, min_result: int = 1, max_result: int = 127):
+    """Multiplie the value by zoom. Cast the result in integer.
+    Return the result if it lies between the extreme limits min_result and max_result.
+    Otherwise, saturates the result at the limit reached.
+    """
+    value = int(value * zoom)
+    if value < min_result:
+        return min_result
+    elif value > max_result:
+        return max_result
+    return value
+
+
+def darker(color, coefficient):
+    """Return a darker color of the color in parameter.
+    The coefficient is between 0 and 1.
+    color is a string in hexadecimal format.
+    """
+    if color[0] == "#" and len(color) == 7:
+        color = color[1:]
+    else:
+        return color
+    R, V, B = color[:2], color[2:4], color[4:]
+    R = hex_digit(str(int(int(R, 16) * coefficient)))
+    V = hex_digit(str(int(int(V, 16) * coefficient)))
+    B = hex_digit(str(int(int(B, 16) * coefficient)))
+    return "#" + R + V + B
+
+
 def cast_rgb_to_hex_color(color_str):
     """If color_str is a color tuple, cast and return this color in an hexadecimal format.
     Otherwise, return the unmodified color string.
@@ -516,7 +545,6 @@ def test_compound(compound: str) -> bool:
         if 0 <= int(compound) < 256:
             return True
     return False
-
 
 def draw_box(can, x_start, y_start, x_end, y_end, **kwargs):
     """Create a rectangle in the canvas (can).

--- a/window_edition.py
+++ b/window_edition.py
@@ -147,6 +147,15 @@ class Window_edition(Window_pattern):
             ["None", "left", "center", "separator", "right"],
             self.destination.justify,
         )
+        self.parameters["comment"] = self.create_entry(
+            6, "Comment", self.destination.comment
+        )
+        self.parameters["comment"].bind(
+            "<FocusOut>",
+            lambda event: self.change_destination_attribut(
+                "comment", self.parameters["comment"].get()
+            ),
+        )
 
     def group_parameters(self):
         self.window.title("Edit group")


### PR DESCRIPTION
+ tl.darker()
+ label et comment justification dans GUI.draw_nodes()
+ affichage du commentaire en couleur plus sombre que l'annotation de type
+ rectification de la marge sur les noms de groupes (affectés par le zoom)
+ rectification de l'épaisseur des pointillés des commentaires et des groupes en fonction du zoom
+ Ajout d'une couleur de commentaire paramétrable dans les préférences